### PR TITLE
Support authentication to blue button api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,16 +102,28 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-netty-http</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-restlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-xstream</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
         </dependency>
         <!-- Added for Camel Kafka -->
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-kafka</artifactId>
-            <version>2.23.2.fuse-760030-redhat-00001</version>
+          <!--  <version>2.23.2.fuse-760030-redhat-00001</version> -->
         </dependency>
         <!-- Servlet -->
         <dependency>
@@ -126,6 +138,10 @@
     </dependencies>
 
     <repositories>
+        <repository>
+            <id>spring-plugin-repository</id>
+            <url>https://repo.spring.io/plugins-release</url>
+        </repository>
         <repository>
             <id>red-hat-ga-repository</id>
             <url>https://maven.repository.redhat.com/ga</url>

--- a/src/main/java/com/redhat/idaas/connect/bluebutton/OAuthToken.java
+++ b/src/main/java/com/redhat/idaas/connect/bluebutton/OAuthToken.java
@@ -1,0 +1,50 @@
+package com.redhat.idaas.connect.bluebutton;
+
+public class OAuthToken {
+    private String access_token;
+    private double expires_in;
+    private String token_type;
+    private String scope;
+    private String refresh_token;
+
+    public String getAccess_token() {
+        return access_token;
+    }
+
+    public void setAccess_token(String access_token) {
+        this.access_token = access_token;
+    }
+
+    public double getExpires_in() {
+        return expires_in;
+    }
+
+    public void setExpires_in(double expires_in) {
+        this.expires_in = expires_in;
+    }
+
+    public String getToken_type() {
+        return token_type;
+    }
+
+    public void setToken_type(String token_type) {
+        this.token_type = token_type;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getRefresh_token() {
+        return refresh_token;
+    }
+
+    public void setRefresh_token(String refresh_token) {
+        this.refresh_token = refresh_token;
+    }
+    
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+bluebutton.client.id=<your registered bluebutton id>
+bluebutton.client.secret=<your registetered bluebutton secret>
+# split your registered callback url into three parts: callback path, host, and port
+bluebutton.callback.path=callback
+bluebutton.callback.host=localhost
+bluebutton.callback.port=3000


### PR DESCRIPTION
@redhat-healthcare-chiefarchitect with this enhancement we no longer require a separate proxy server for authentication. The fuse project itself hosts the callback for authentication.

Use a web browser to open page `localhost:3000/bluebutton`, it will lead you to the log in page. Upon success it will then fetch blue button data and send it through Kafka.